### PR TITLE
Update hackathon page + hide from navbar

### DIFF
--- a/docs/.pages
+++ b/docs/.pages
@@ -4,4 +4,3 @@ nav:
     - community.md
     - governance.md
     - code-of-conduct.md
-    - ...

--- a/docs/hackathon-2023.md
+++ b/docs/hackathon-2023.md
@@ -1,8 +1,7 @@
 # Hackathon 2023
 
-The [GA4GH 11th Plenary meeting](https://broadinstitute.swoogo.com/ga4gh11thplenary) will be held in
-San Francisco September 19-22, 2023. We are currently planning an in-person hackathon in the days
-before the event. 
+We are having an in-person hackathon on September 17-18, 2023 at [Mindspace San Francisco](https://www.google.com/maps/place/Mindspace+San+Francisco/data=!4m2!3m1!19sChIJ1SY5AOOBhYARpyx2-yXz53M). The goal of the hackathon is to have new and existing collaborators develop and advance Biocommons projects.
 
-Join the [biocommons-hacakathons](https://groups.google.com/g/biocommons-hackathons) list to learn
-more.  We may consider a remote hacking event if there's sufficient interest.
+Visit the [hackathon-2023 repo](https://github.com/biocommons/hackathon-2023) for hackathon project proposals. Please feel free to submit your ideas here.
+
+Join the [hackathon-planning Slack channel](https://join.slack.com/t/biocommons/shared_invite/zt-1wknmereq-QI2WNNvFU5vMdmwNNNa02g) to learn more.

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,8 +13,3 @@
   </div>
 
 </div>
-
-!!! note "Biocommons Hackathon in September 2023"
-
-    The [GA4GH 11th Plenary meeting](https://broadinstitute.swoogo.com/ga4gh11thplenary) will be held in San Francisco September 19-22, 2023. We are
-    currently planning an in-person hackathon in the days before the event.  See [Hackathon 2023](hackathon-2023.md) for more.


### PR DESCRIPTION
Updates information about the hackathon. I also removed the hackathon note and removed the hackathon from the navbar since we are doing invite only